### PR TITLE
Second stab at #6

### DIFF
--- a/src/bafr.js
+++ b/src/bafr.js
@@ -1,9 +1,9 @@
 import fs from "fs";
-import path from "path";
 import toml from "toml";
 import yaml from "yaml";
 import {globby} from "globby";
 import Replacer from "./replacer.js";
+import { resolvePath } from "./util.js";
 
 let parsers = {
 	toml,
@@ -43,8 +43,7 @@ export default class Bafr {
 				outputPath = outputPath.replace(/\.[^.]+$/, this.script.extension.replace(/^\.?/, "."));
 			}
 			if (this.script.path) {
-				let outputPathParsed = path.parse(outputPath);
-				outputPath = path.resolve(outputPathParsed.dir, this.script.path, outputPathParsed.base);
+				outputPath = resolvePath(outputPath, this.script.path);
 			}
 		}
 

--- a/src/bafr.js
+++ b/src/bafr.js
@@ -43,7 +43,8 @@ export default class Bafr {
 				outputPath = outputPath.replace(/\.[^.]+$/, this.script.extension.replace(/^\.?/, "."));
 			}
 			if (this.script.path) {
-				outputPath = path.join(this.script.path, outputPath);
+				let outputPathParsed = path.parse(outputPath);
+				outputPath = path.resolve(outputPathParsed.dir, this.script.path, outputPathParsed.base);
 			}
 		}
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,5 @@
+import path from "path";
+
 export function parseArgs (argv = process.argv, defaults = {}) {
 	argv = argv.slice(2);
 	let script = argv.shift();
@@ -44,4 +46,15 @@ export function formatTimeTaken (ms) {
 	}
 
 	return `${ n.toPrecision(3) } ${ unit }`;
+}
+
+/**
+ * Resolves a target path relative to a base path.
+ * @param {string} from - The base path.
+ * @param {string} to - The target path to resolve to.
+ * @returns {string} The resolved path.
+ */
+export function resolvePath (from, to) {
+	let fromParsed = path.parse(from);
+	return path.resolve(fromParsed.dir, to, fromParsed.base);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,12 @@
 import compile from "./compile.js";
 import replace from "./replace.js";
+import {default as util} from "./util.js";
 
 export default {
 	name: "All tests",
 	tests: [
 		compile,
 		replace,
+		util,
 	]
 }

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,38 @@
+import { resolvePath } from "../src/util.js";
+
+export default {
+	name: "Utility functions",
+	tests: [{
+			name: "resolvePath()",
+			run (from, to) {
+				let path = resolvePath(from, to);
+				return to.startsWith("/") ? path : path.replace(process.cwd() + "/", "");
+			},
+			getName (from, to) {
+				return to;
+			},
+			tests: [
+				{
+					args: ["papers/foo/bar.tex", "."],
+					expect: "papers/foo/bar.tex",
+				},
+				{
+					args: ["papers/foo/bar.tex", ".."],
+					expect: "papers/bar.tex",
+				},
+				{
+					args: ["papers/foo/bar.tex", "../../src"],
+					expect: "src/bar.tex",
+				},
+				{
+					args: ["papers/foo/bar.tex", "baz/yolo"],
+					expect: "papers/foo/baz/yolo/bar.tex",
+				},
+				{
+					args: ["papers/foo/bar.tex", "/baz"],
+					expect: "/baz/bar.tex",
+				},
+			],
+		},
+	],
+}

--- a/test/util.js
+++ b/test/util.js
@@ -2,7 +2,8 @@ import { resolvePath } from "../src/util.js";
 
 export default {
 	name: "Utility functions",
-	tests: [{
+	tests: [
+		{
 			name: "resolvePath()",
 			run (from, to) {
 				let path = resolvePath(from, to);


### PR DESCRIPTION
**Tests**

```yaml
files: "papers/foo/bar.tex"
path: ".." # Resolves to papers/bar.tex
replace:
- ["{figure*}", "{figure}"]
```

```yaml
files: "papers/foo/bar.tex"
path: "../../src" # Resolves to src/bar.tex
replace:
- ["{figure*}", "{figure}"]
```

```yaml
files: "papers/foo/bar.tex"
path: "baz" # Resolves to papers/foo/baz/bar.tex
replace:
- ["{figure*}", "{figure}"]
```

```yaml
files: "papers/foo/bar.tex"
path: "/baz" # Resolves to /baz/bar.tex
replace:
- ["{figure*}", "{figure}"]
```
