### PR TITLE
Use the original `to` on every replacement

### DIFF
--- a/src/replacer.js
+++ b/src/replacer.js
@@ -76,10 +76,11 @@ export default class Replacer {
 					let simpleTo = !this.literal && !this.replace;
 					content = content.replaceAll(from, simpleTo ? to : (...args) => {
 						let resolvedArgs = resolveReplacementArgs(args);
+						to = this.to ?? this.insert ?? "";
 
 						if (!this.literal) {
 							// Replace special replacement patterns
-							to = emulateStringReplacement(resolvedArgs);
+							to = emulateStringReplacement(resolvedArgs, to);
 						}
 
 						if (this.replace) {


### PR DESCRIPTION
instead of the modified one and pass it to `emulateStringReplacement()`