### PR TITLE
Pass `options` to every transformation

### DIFF
--- a/src/replacer.js
+++ b/src/replacer.js
@@ -106,7 +106,7 @@ export default class Replacer {
 		}
 		else if (this.replace) {
 			for (let replacement of this.replace) {
-				content = replacement.transform(content);
+				content = replacement.transform(content, options);
 			}
 		}
 

--- a/src/replacer.js
+++ b/src/replacer.js
@@ -92,7 +92,7 @@ export default class Replacer {
 							if (this.replace) {
 								// Child replacements
 								for (let replacement of this.replace) {
-									to = replacement.transform(to);
+									to = replacement.transform(to, options);
 								}
 							}
 


### PR DESCRIPTION
Otherwise, there is no way to apply replacements to a subset of files.

I wonder if it ever works. 🤔

There is another place where we call `transform()`: https://github.com/LeaVerou/brep/blob/312f4436666ecace4b894f66536b63f65c5aef48/src/replacer.js#L95 Should we also pass `options` in this case?